### PR TITLE
✨Support save int16 iand int8 mage

### DIFF
--- a/Fast_BigTiff_Write.m
+++ b/Fast_BigTiff_Write.m
@@ -94,6 +94,8 @@ classdef Fast_BigTiff_Write  < handle
                         bps = 2;sf=1;
                     case {'uint8'}
                         bps = 1;sf=1;
+                    case {'int16'}
+                        bps = 2;sf=2;
                     otherwise
                         error('class not supported')
                 end

--- a/Fast_BigTiff_Write.m
+++ b/Fast_BigTiff_Write.m
@@ -96,6 +96,8 @@ classdef Fast_BigTiff_Write  < handle
                         bps = 1;sf=1;
                     case {'int16'}
                         bps = 2;sf=2;
+                    case {'int8'}
+                        bps = 1;sf=2;
                     otherwise
                         error('class not supported')
                 end

--- a/Fast_Tiff_Write.m
+++ b/Fast_Tiff_Write.m
@@ -95,6 +95,8 @@ classdef Fast_Tiff_Write  < handle
                         bps = 1;sf=1;
                     case {'int16'}
                         bps = 2;sf=2;
+                    case {'int8'}
+                        bps = 1;sf=2;
                     otherwise
                         error('class not supported')
                 end

--- a/Fast_Tiff_Write.m
+++ b/Fast_Tiff_Write.m
@@ -93,6 +93,8 @@ classdef Fast_Tiff_Write  < handle
                         bps = 2;sf=1;
                     case {'uint8'}
                         bps = 1;sf=1;
+                    case {'int16'}
+                        bps = 2;sf=2;
                     otherwise
                         error('class not supported')
                 end


### PR DESCRIPTION
```diff
                switch obj.classname
                    case {'double'}
                        warning('converting to from 64-bit double precision to 32-bit single precision')
                        img=single(img);
                        obj.classname='single';
                        bps = 4;sf=3;
                    case {'single'}
                        bps = 4;sf=3;
                    case {'uint16'}
                        bps = 2;sf=1;
                    case {'uint8'}
                        bps = 1;sf=1;
+                    case {'int16'}
+                       bps = 2;sf=2;
+                    case {'int8'}
+                       bps = 1;sf=2;
                    otherwise
                        error('class not supported')
                end
```